### PR TITLE
chore: normalize package repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/lxs24sxl/vite-plugin-html-env.git"
+    "url": "git+https://github.com/lxs24sxl/vite-plugin-html-env.git"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
## Summary
- Replace the published package repository URL with a public HTTPS Git URL.

## Verification
- Confirmed the compare diff only changes the repository URL in package.json.
